### PR TITLE
simple download MediaMessage, custom sticker metadata

### DIFF
--- a/src/wamd/utils.py
+++ b/src/wamd/utils.py
@@ -513,3 +513,37 @@ def isGroupJid(jid):
 def jidNormalize(jid):
     user, _, _, server = splitJid(jid)
     return "%s@%s" % (user, server)
+
+def stickerExif(
+    packname: str,
+    author: str,
+    stickerPackID: str = ''.join(
+        map(hex, os.urandom(32))
+    ).replace('0x', ''),
+    googlelink: str = '',
+    applelink: str = '',
+    emoji: list[str, str] = []
+) -> bytes:
+    code = [0x00, 0x00, 0x16, 0x00, 0x00, 0x00]
+    exif = {
+            "sticker-pack-id": stickerPackID,
+            "sticker-pack-name": packname,
+            "sticker-pack-publisher": author,
+            "android-app-store-link": googlelink,
+            "ios-app-store-link": applelink,
+            "emoji": emoji
+        }
+    length = exif.__str__().__len__()
+    if length > 256:
+        length -= 256
+        code.insert(0, 0x01)
+    else:
+        code.insert(0, 0x00)
+    return bytes([
+        0x49, 0x49, 0x2A, 0x00, 0x08,
+        0x00, 0x00, 0x00, 0x01, 0x00,
+        0x41, 0x57, 0x07, 0x00])+bytes([
+            int("0x0"+hex(
+                length)[2:].__str__() if length < 16 else hex(
+                    length)[2:].__str__(), 16)
+        ])+bytes(code)+exif.__str__().encode()


### PR DESCRIPTION
# Download media from message
```python
from wamd.http import downloadMedia
from wamd.messages import MediaMessage


def onMessage(connection, message):
    if isinstance(message, MediaMessage):
        fileContent = yield downloadMedia(message) 
```
# Custom sticker metadata (packname, author, etc.) 
```python
from wamd.http import mediaTypeFromMime
from wamd.utils import stickerExif
from wamd.messages import MediaMessage
from io import ByteslO
from PIL import Image


def onMessage(connection, message):
    if isinstance(message, MediaMessage) and mediaTypeFromMime(message['mimetype']) == 'image':
        fileContent = yield downloadMedia(message) Image.open(BytesIO(fileContent)).save('sticker.webp', exif=stickerExif('packname', 'author'))
        connection.relayMessage(MediaMessage(to=message['from'], url='sticker.webp')) 
```